### PR TITLE
Fix truncated `[Tomorrow]' and empty opening hours

### DIFF
--- a/functions.ts
+++ b/functions.ts
@@ -59,25 +59,19 @@ function printUpcomingOpenings(place: Place): string {
     var time: number = getExtendedTime();
     var output: string = "";
 
-    for (var i=0; i<hours.length; i++) {
-        var x: Interval = hours[i];
-        // Add all of the intervals that haven't ended yet to the output
-        if (time < x.getClose()) {
-            output += x.getIntervalString() + " and ";
-        }
-    }
+    // Add all of the intervals that haven't ended yet to the output
+    output += hours.filter(x => time < x.getClose()).map(x => x.getIntervalString()).join(" and ");
+    
     // If there are no intervals today, or they all already ended,
     // let's show what's open tomorrow.
     if ((hours == Interval.none) || (output == "")) {
         var hours = place.getHoursForTomorrow();
-        if (hours == Interval.none) return "closed for today and tomorrow";
+        if (hours.length === 0 || hours == Interval.none)
+           return "closed for today and tomorrow";
         output += "[Tomorrow] "
-        for (var i=0; i<hours.length; i++) {
-            var x: Interval = hours[i];
-            output += x.getIntervalString() + " and ";
-        }
+        output += hours.map(x => x.getIntervalString()).join(" and ");
     }
-    return output.slice(0, -5);  //remove that annoying last " and "
+    return output;
 }
 
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/6357330/32403735-c9ca3420-c0fe-11e7-9a8f-bb71b7199e9a.png)

After:
![image](https://user-images.githubusercontent.com/6357330/32403738-d482af46-c0fe-11e7-93f2-3f9a14b62623.png)
